### PR TITLE
Update RelURL for latest Hugo syntax

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {{ $.Scratch.Set "Title" (default .Title (index .Site.Params.text (print "title_" (lower .Title)))) }}
     <title>{{ if eq ($.Scratch.Get "Title") .Site.Title }}{{ .Site.Title }}{{ else }}{{ ($.Scratch.Get "Title") }} | {{ .Site.Title }}{{ end }}</title>
-    <link rel="stylesheet" href="{{ "/css/style.css" | relURL }}" />
-    <link rel="stylesheet" href="{{ "/css/fonts.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "css/style.css" | relURL }}" />
+    <link rel="stylesheet" href="{{ "css/fonts.css" | relURL }}" />
     {{ partial "head_custom.html" . }}
   </head>
 


### PR DESCRIPTION
Hugo has a change in v0.101.0 for relUrl if there is a slash beforehand.  This link for more details: https://github.com/gohugoio/hugo/releases/tag/v0.101.0 and https://github.com/gohugoio/hugo/commit/a5a4422aaeffe0e9df713cf09c73a9cc423a2e1e.

Suggesting this change so CSS and related resources load correctly.