### PR TITLE
fixing template issue related tags page and category page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,9 +4,11 @@
 <div class="article-meta">
 
   <div class="categories">
-  {{ range $i, $e := .Params.categories }}
-    {{ if $i }} &hercon; {{ end }}<a href="{{ relURL (print "/categories/" $e | urlize) }}">{{ $e }}</a>
+{{ range $i, $e := .Params.categories }}
+  {{ with $.Site.GetPage (printf "taxonomyTerm/categories/%s" $e) }}
+    {{ if $i }} &hercon; {{ end }}<a href="{{ .Permalink }}">{{ $e }}</a>
   {{ end }}
+{{ end }}
   </div>
 
   <h1><span class="title">{{ .Title }}</span></h1>
@@ -16,7 +18,12 @@
   {{ end }}
 
   {{ with .Params.tags }}
-  <p>{{ default "Tags: " (index $.Site.Params.text "tags") }}{{ range $i, $e := . }}{{ if $i }}; {{ end }}<a href="{{ relURL (print "/tags/" $e | urlize) }}">{{ $e }}</a>{{ end }}
+  <p>{{ default "Tags: " (index $.Site.Params.text "tags") }}
+    {{ range $i, $e := . }}
+      {{ with $.Site.GetPage (printf "taxonomyTerm/tags/%s" $e) }}
+        {{ if $i }}; {{ end }}<a href="{{ .Permalink }}">{{ $e }}</a>
+      {{ end }}
+    {{ end }}
   </p>
   {{ end }}
   {{ partial "meta.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,11 +4,9 @@
 <div class="article-meta">
 
   <div class="categories">
-{{ range $i, $e := .Params.categories }}
-  {{ with $.Site.GetPage (printf "taxonomyTerm/categories/%s" $e) }}
-    {{ if $i }} &hercon; {{ end }}<a href="{{ .Permalink }}">{{ $e }}</a>
+  {{ range $i, $e := .Params.categories }}
+    {{ if $i }} &hercon; {{ end }}<a href="{{ relURL (print "/categories/" $e | urlize) }}">{{ $e }}</a>
   {{ end }}
-{{ end }}
   </div>
 
   <h1><span class="title">{{ .Title }}</span></h1>
@@ -18,12 +16,7 @@
   {{ end }}
 
   {{ with .Params.tags }}
-  <p>{{ default "Tags: " (index $.Site.Params.text "tags") }}
-    {{ range $i, $e := . }}
-      {{ with $.Site.GetPage (printf "taxonomyTerm/tags/%s" $e) }}
-        {{ if $i }}; {{ end }}<a href="{{ .Permalink }}">{{ $e }}</a>
-      {{ end }}
-    {{ end }}
+  <p>{{ default "Tags: " (index $.Site.Params.text "tags") }}{{ range $i, $e := . }}{{ if $i }}; {{ end }}<a href="{{ relURL (print "/tags/" ($e | urlize)) }}">{{ $e }}</a>{{ end }}
   </p>
   {{ end }}
   {{ partial "meta.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
 <ul class="terms">
   {{ range $key, $value := .Data.Terms }}
   <li>
-    <a href="{{ (print "/" $.Data.Plural "/" $key | urlize ) | relURL}}">
+    <a href="{{ (print "/" $.Data.Plural "/" $key | urlize) | relURL }}">
       {{ $key }}
     </a>
     ({{ len $value }})

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -8,7 +8,7 @@
 <ul class="terms">
   {{ range $key, $value := .Data.Terms }}
   <li>
-    <a href="{{ (print "/" $.Data.Plural "/" $key) | relURL }}">
+    <a href="{{ (print "/" $.Data.Plural "/" $key | urlize ) | relURL}}">
       {{ $key }}
     </a>
     ({{ len $value }})


### PR DESCRIPTION
While building the site, I encountered an issue with how content tags and category are rendered—specifically when a tag or category contains spaces. the issue was also similar in single page partial at the tags level.

I updated the partial to use the urlize filter, which converts spaces into hyphens (-). This ensures that tag URLs are correctly formatted and render properly, even when the tag label contains spaces using their urlized version (e.g., riga di comando becomes /tags/riga-di-comando/).